### PR TITLE
Google Cloud VPC network

### DIFF
--- a/sys/src/9/ip/ip.c
+++ b/sys/src/9/ip/ip.c
@@ -129,6 +129,7 @@ ipoput4(Fs *f, Block *bp, int gating, int ttl, int tos, Conv *c)
 	Route *r, *sr;
 	IP *ip;
 	int rv = 0;
+	uchar v4dst[IPv4addrlen];
 
 	ip = f->ip;
 
@@ -169,7 +170,11 @@ ipoput4(Fs *f, Block *bp, int gating, int ttl, int tos, Conv *c)
 		gate = eh->dst;
 	else
 	if(r->type & (Rbcast|Rmulti)) {
-		gate = eh->dst;
+		if(nhgetl(r->v4.gate) == 0){
+			hnputl(v4dst, r->v4.address);
+			gate = v4dst;
+		}else
+			gate = eh->dst;
 		sr = v4lookup(f, eh->src, nil);
 		if(sr != nil && (sr->type & Runi))
 			ifc = sr->ifc;

--- a/sys/src/9/ip/iproute.c
+++ b/sys/src/9/ip/iproute.c
@@ -493,6 +493,7 @@ v4lookup(Fs *f, uchar *a, Conv *c)
 		return c->r;
 
 	la = nhgetl(a);
+again:
 	q = nil;
 	for(p=f->v4root[V4H(la)]; p;)
 		if(la >= p->v4.address) {
@@ -511,8 +512,14 @@ v4lookup(Fs *f, uchar *a, Conv *c)
 		} else
 			v4tov6(gate, q->v4.gate);
 		ifc = findipifc(f, gate, q->type);
-		if(ifc == nil)
+		if(ifc == nil){
+			/* find a direct attached route */
+			if(q->v4.address == 0 && q->v4.endaddress == ~0){
+				la = nhgetl(q->v4.gate);
+				goto again;
+			}
 			return nil;
+		}
 		q->ifc = ifc;
 		q->ifcid = ifc->ifcid;
 	}
@@ -817,6 +824,7 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 	uchar gate[IPaddrlen];
 	IPaux *a, *na;
 	Route *q;
+	uchar type;
 
 	cb = parsecmd(p, n);
 	if(waserror()){
@@ -863,9 +871,12 @@ routewrite(Fs *f, Chan *c, char *p, int n)
 			a = c->aux;
 			tag = a->tag;
 		}
-		if(memcmp(addr, v4prefix, IPv4off) == 0)
-			v4addroute(f, tag, addr+IPv4off, mask+IPv4off, gate+IPv4off, 0);
-		else
+		if(memcmp(addr, v4prefix, IPv4off) == 0){
+			type = 0;
+			if(ipcmp(mask, IPallbits) == 0)
+				type = Rbcast;
+			v4addroute(f, tag, addr+IPv4off, mask+IPv4off, gate+IPv4off, type);
+		}else
 			v6addroute(f, tag, addr, mask, gate, 0);
 	} else if(strcmp(cb->f[0], "tag") == 0) {
 		if(cb->nf < 2)

--- a/sys/src/cmd/ip/dhcp.h
+++ b/sys/src/cmd/ip/dhcp.h
@@ -115,6 +115,8 @@ enum
 	ODpxeni=		94,
 	ODpxeguid=		97,
 
+	ODcstaticroutes=	121, /* see rfc 3442 */
+
 	/* plan9 vendor info options, v4 addresses only (deprecated) */
 	OP9fsv4=		128,	/* plan9 file servers */
 	OP9authv4=		129,	/* plan9 auth servers */

--- a/sys/src/cmd/ip/ipconfig/ipconfig.h
+++ b/sys/src/cmd/ip/ipconfig/ipconfig.h
@@ -26,6 +26,7 @@ struct Conf
 	uchar	fs[2*IPaddrlen];
 	uchar	auth[2*IPaddrlen];
 	uchar	ntp[IPaddrlen];
+	uchar	iproutes[6*IPaddrlen]; /* mask, network, gateway */
 	int	mtu;
 
 	/* dhcp specific */

--- a/sys/src/cmd/ip/ipconfig/main.c
+++ b/sys/src/cmd/ip/ipconfig/main.c
@@ -39,6 +39,7 @@ enum
 	Tushort,
 	Tulong,
 	Tvec,
+	Tshortaddrs,
 };
 
 typedef struct Option Option;
@@ -129,6 +130,7 @@ Option option[256] =
 [ODclientid]		{ "clientid",		Tvec },
 [ODtftpserver]		{ "tftp",		Taddr },
 [ODbootfile]		{ "bootfile",		Tstr },
+[ODcstaticroutes]	{ "staticroutes",	Tshortaddrs },
 };
 
 uchar defrequested[] = {
@@ -176,6 +178,7 @@ char *verbs[] = {
 };
 
 void	adddefroute(char*, uchar*);
+void	addroute(char*, char*, char*, char*);
 int	addoption(char*);
 void	binddevice(void);
 void	bootprequest(void);
@@ -204,6 +207,7 @@ uchar*	optadd(uchar*, int, void*, int);
 uchar*	optaddulong(uchar*, int, ulong);
 uchar*	optaddvec(uchar*, int, uchar*, int);
 int	optgetaddrs(uchar*, int, uchar*, int);
+int	optgetshortaddrs(uchar*, int, uchar*, int);
 int	optgetp9addrs(uchar*, int, uchar*, int);
 int	optgetaddr(uchar*, int, uchar*);
 int	optgetbyte(uchar*, int);
@@ -717,6 +721,18 @@ dounbind(void)
 void
 adddefroute(char *mpoint, uchar *gaddr)
 {
+	char buf[40];
+
+	snprint(buf, sizeof buf, "%I", gaddr);
+	if(isv4(gaddr))
+		addroute(mpoint, "0", "0", buf);
+	else
+		addroute(mpoint, "::", "/0", buf);
+}
+
+void
+addroute(char *mpoint, char *addr, char *mask, char *gaddr)
+{
 	char buf[256];
 	int cfd;
 
@@ -725,10 +741,7 @@ adddefroute(char *mpoint, uchar *gaddr)
 	if(cfd < 0)
 		return;
 
-	if(isv4(gaddr))
-		fprint(cfd, "add 0 0 %I", gaddr);
-	else
-		fprint(cfd, "add :: /0 %I", gaddr);
+	fprint(cfd, "add %s %s %s", addr, mask, gaddr);
 	close(cfd);
 }
 
@@ -822,6 +835,8 @@ ip4cfg(void)
 {
 	char buf[256];
 	int n;
+	uchar *p, *e;
+	char addr[16], mask[16], gaddr[16];
 
 	if(!validip(conf.laddr))
 		return -1;
@@ -853,6 +868,15 @@ ip4cfg(void)
 		}
 	}
 
+	e = conf.iproutes + sizeof conf.iproutes;
+	for(p = conf.iproutes; p < e; p += IPaddrlen*3){
+		if(ipcmp(p, IPnoaddr) == 0)
+			break;
+		snprint(addr, sizeof addr, "%I", p+IPaddrlen);
+		snprint(mask, sizeof mask, "%M", p);
+		snprint(gaddr, sizeof gaddr, "%I", p+IPaddrlen*2);
+		addroute(conf.mpoint, addr, mask, gaddr);
+	}
 	if(beprimary==1 && validip(conf.gaddr))
 		adddefroute(conf.mpoint, conf.gaddr);
 
@@ -1287,6 +1311,11 @@ dhcprecv(void)
 		/* get anything else we asked for */
 		getoptions(bp->optdata);
 
+		/* get static routes */
+		n = optgetshortaddrs(bp->optdata, ODcstaticroutes, conf.iproutes, 6);
+		for(i = 0; i < n; i++)
+			DEBUG("iproutes=%I ", conf.iproutes + i*IPaddrlen);
+
 		/* get plan9-specific options */
 		n = optgetvec(bp->optdata, OBvendorinfo, vopts, sizeof vopts-1);
 		if(n > 0 && parseoptions(vopts, n) == 0){
@@ -1535,6 +1564,39 @@ optgetaddrs(uchar *p, int op, uchar *ip, int n)
 	for(i = 0; i < len; i++)
 		v4tov6(&ip[i*IPaddrlen], &p[i*IPv4addrlen]);
 	return i;
+}
+
+int
+optgetshortaddrs(uchar *p, int op, uchar *ip, int n)
+{
+	int len, i, l;
+	uchar buf[IPv4addrlen];
+	char mask[5];
+
+	len = 5;
+	p = optget(p, op, &len);
+	if(p == nil)
+		return 0;
+	n /= 3;
+	for(i = 0; i < n; i++){
+		l = (*p+7) / 8;
+		snprint(mask, sizeof mask, "/%d", 96 + *p++);
+		parseipmask(ip, mask);
+		ip += IPaddrlen;
+
+		memset(buf, 0, sizeof buf);
+		memmove(buf, p, l);
+		v4tov6(ip, buf);
+		ip += IPaddrlen;
+		p += l;
+
+		v4tov6(ip, p);
+		ip += IPaddrlen;
+		p += IPv4addrlen;
+	}
+	if(i > n)
+		i = n;
+	return i * 3;
 }
 
 /* expect at most n addresses; ip[] only has room for that many */
@@ -1932,7 +1994,11 @@ optgetx(uchar *p, uchar opt)
 			s = smprint("%s=%I", o->name, ip);
 		break;
 	case Taddrs:
-		n = optgetaddrs(p, opt, ips, 16);
+	case Tshortaddrs:
+		if(o->type == Taddrs)
+			n = optgetaddrs(p, opt, ips, 16);
+		else
+			n = optgetshortaddrs(p, opt, ips, 16);
 		if(n > 0)
 			s = smprint("%s=%I", o->name, ips);
 		for(i = 1; i < n; i++){


### PR DESCRIPTION
On the Google Cloud, broadcasting packet can't reached to other instances in the same zone. Instead, all packets sent by the instance must communicate to other host via the default gateway.

The packet sent by DHCP server contains two Classless Static Routes(121) option.

```
[0]
mask=32
network=0.0.0.0
nexthop=10.xxx.xxx.1

[1]
mask=32
network=10.xxx.xxx.1
nexthop=0.0.0.0
```

`nexthop=0.0.0.0` means the route points to an interface.
https://www.cisco.com/c/en/us/support/docs/dial-access/floating-static-route/118263-technote-nexthop-00.html

This p-r conflicts to **ip-ipconfig-mask.diff**.